### PR TITLE
Update for Django >= 3.2

### DIFF
--- a/passlib/apps.py
+++ b/passlib/apps.py
@@ -72,10 +72,7 @@ custom_app_context = LazyCryptContext(
 )
 
 
-# -----------------------------------------------------------------------
-# 1.0
-# -----------------------------------------------------------------------
-
+# Django >= 1.0
 _django10_schemes = [
     "django_salted_sha1",
     "django_salted_md5",
@@ -90,10 +87,7 @@ django10_context = LazyCryptContext(
     deprecated=["hex_md5"],
 )
 
-# -----------------------------------------------------------------------
-# 1.4
-# -----------------------------------------------------------------------
-
+# Django >= 1.4
 _django14_schemes = [
     "django_pbkdf2_sha256",
     "django_pbkdf2_sha1",
@@ -105,10 +99,7 @@ django14_context = LazyCryptContext(
     deprecated=_django10_schemes,
 )
 
-# -----------------------------------------------------------------------
-# 1.6
-# -----------------------------------------------------------------------
-
+# Django >= 1.6
 _django16_schemes = list(_django14_schemes)
 _django16_schemes.insert(1, "django_bcrypt_sha256")
 django16_context = LazyCryptContext(
@@ -116,10 +107,7 @@ django16_context = LazyCryptContext(
     deprecated=_django10_schemes,
 )
 
-# -----------------------------------------------------------------------
-# 1.10
-# -----------------------------------------------------------------------
-
+# Django >=1.10
 _django_110_schemes = [
     "django_pbkdf2_sha256",
     "django_pbkdf2_sha1",
@@ -130,26 +118,19 @@ _django_110_schemes = [
 ]
 django110_context = LazyCryptContext(schemes=_django_110_schemes)
 
-# -----------------------------------------------------------------------
-# 2.1
-# -----------------------------------------------------------------------
-
+# Django >=2.1
 _django21_schemes = list(_django_110_schemes)
 _django21_schemes.remove("django_bcrypt")
 django21_context = LazyCryptContext(schemes=_django21_schemes)
 
-# -----------------------------------------------------------------------
-# 3.1
-# -----------------------------------------------------------------------
-
+# Django >=3.1
 _django31_schemes = list(_django21_schemes)
-_django31_schemes.remove("django_pbkdf2_sha1")
-django31_context = LazyCryptContext(schemes=_django31_schemes)
+django31_context = LazyCryptContext(
+    schemes=_django31_schemes, 
+    deprecated=["django_pbkdf2_sha1"]
+)
 
-# -----------------------------------------------------------------------
-# latest
-# -----------------------------------------------------------------------
-
+# Django latest
 # this will always point to latest version in passlib
 django_context = django21_context
 

--- a/passlib/apps.py
+++ b/passlib/apps.py
@@ -139,6 +139,14 @@ _django21_schemes.remove("django_bcrypt")
 django21_context = LazyCryptContext(schemes=_django21_schemes)
 
 # -----------------------------------------------------------------------
+# 3.1
+# -----------------------------------------------------------------------
+
+_django31_schemes = list(_django21_schemes)
+_django31_schemes.remove("django_pbkdf2_sha1")
+django31_context = LazyCryptContext(schemes=_django31_schemes)
+
+# -----------------------------------------------------------------------
 # latest
 # -----------------------------------------------------------------------
 

--- a/tests/test_ext_django.py
+++ b/tests/test_ext_django.py
@@ -186,7 +186,12 @@ def _modify_django_config(kwds, sha_rounds=None):
 #      could then separate out "validation of djangoXX_context objects"
 #      and "validation that individual hashers match django".
 #      or maybe add a "get_django_context(django_version)" helper to passlib.apps?
-if DJANGO_VERSION >= (2, 1):
+salt_size = 12
+if DJANGO_VERSION >= (3, 1):
+    stock_config = _modify_django_config(_apps.django31_context)
+    if DJANGO_VERSION >= (3, 2):
+        salt_size=22
+elif DJANGO_VERSION >= (2, 1):
     stock_config = _modify_django_config(_apps.django21_context)
 elif DJANGO_VERSION >= (1, 10):
     stock_config = _modify_django_config(_apps.django110_context)
@@ -194,12 +199,12 @@ else:
     # assert DJANGO_VERSION >= (1, 8)
     stock_config = _modify_django_config(_apps.django16_context)
 
-
 sample_hashes = dict(
     django_pbkdf2_sha256=(
         "not a password",
         django_pbkdf2_sha256.using(
-            rounds=stock_config.get("django_pbkdf2_sha256__default_rounds")
+            rounds=stock_config.get("django_pbkdf2_sha256__default_rounds"),
+            salt_size=salt_size
         ).hash("not a password"),
     )
 )
@@ -750,6 +755,7 @@ class DjangoBehaviorTest(_ExtensionTest):
 
         # check against invalid password
         assert not user.check_password(None)
+
         ##self.assertFalse(user.check_password(''))
         assert not user.check_password(other)
         self.assert_valid_password(user, hash)


### PR DESCRIPTION
Django 3.1 deprecated sha1
Django 3.2 increased salt entropy from 71 to 128 bits

* Add django31_context that removes sha1 from tests if django >= 3.1
* Add increase default salt length

Resolves #2