### PR TITLE
Update for BCrypt wrap bug detected

### DIFF
--- a/passlib/handlers/bcrypt.py
+++ b/passlib/handlers/bcrypt.py
@@ -43,7 +43,7 @@ IDENT_2B = "$2b$"
 _BNULL = b"\x00"
 
 # reference hash of "test", used in various self-checks
-TEST_HASH_2A = "$2a$04$5BJqKfqMQvV7nS.yUguNcueVirQqDBGaLXSqj.rs.pZPlNR0UX/HK"
+TEST_HASH_2A = f"{IDENT_2A}04$5BJqKfqMQvV7nS.yUguNcueVirQqDBGaLXSqj.rs.pZPlNR0UX/HK"
 
 
 def _detect_pybcrypt():
@@ -426,9 +426,9 @@ class _BcryptCommon(  # type: ignore[misc]
         result = safe_verify("test", TEST_HASH_2A)
         if result is NotImplemented:
             # 2a support is required, and should always be present
-            raise RuntimeError(f"{backend} lacks support for $2a$ hashes")
+            raise RuntimeError(f"{backend} lacks support for {IDENT_2A} hashes")
         if not result:
-            raise RuntimeError(f"{backend} incorrectly rejected $2a$ hash")
+            raise RuntimeError(f"{backend} incorrectly rejected {IDENT_2A} hash")
         assert_lacks_8bit_bug(IDENT_2A)
         if detect_wrap_bug(IDENT_2A):
             if backend == "os_crypt":
@@ -436,8 +436,8 @@ class _BcryptCommon(  # type: ignore[misc]
                 # they'll have proper 2b implementation which will be used for new hashes.
                 # so even if we didn't have a workaround, this bug wouldn't be a concern.
                 logger.debug(
-                    "%r backend has $2a$ bsd wraparound bug, enabling workaround",
-                    backend,
+                    "%r backend has %s bsd wraparound bug, enabling workaround",
+                    backend, IDENT_2A
                 )
             else:
                 # installed library has the bug -- want to let users know,
@@ -454,13 +454,13 @@ class _BcryptCommon(  # type: ignore[misc]
         # ----------------------------------------------------------------
         # check for 2y support
         # ----------------------------------------------------------------
-        test_hash_2y = TEST_HASH_2A.replace("2a", "2y")
+        test_hash_2y = TEST_HASH_2A.replace(IDENT_2A, IDENT_2Y)
         result = safe_verify("test", test_hash_2y)
         if result is NotImplemented:
             mixin_cls._lacks_2y_support = True
-            logger.debug("%r backend lacks $2y$ support, enabling workaround", backend)
+            logger.debug("%r backend lacks %s support, enabling workaround", backend, IDENT_2Y)
         elif not result:
-            raise RuntimeError(f"{backend} incorrectly rejected $2y$ hash")
+            raise RuntimeError(f"{backend} incorrectly rejected {IDENT_2Y} hash")
         else:
             # NOTE: Not using this as fallback candidate,
             #       lacks wide enough support across implementations.
@@ -474,13 +474,13 @@ class _BcryptCommon(  # type: ignore[misc]
         # ----------------------------------------------------------------
         # check for 2b support
         # ----------------------------------------------------------------
-        test_hash_2b = TEST_HASH_2A.replace("2a", "2b")
+        test_hash_2b = TEST_HASH_2A.replace(IDENT_2A, IDENT_2B)
         result = safe_verify("test", test_hash_2b)
         if result is NotImplemented:
             mixin_cls._lacks_2b_support = True
-            logger.debug("%r backend lacks $2b$ support, enabling workaround", backend)
+            logger.debug("%r backend lacks %s support, enabling workaround", backend, IDENT_2B)
         elif not result:
-            raise RuntimeError(f"{backend} incorrectly rejected $2b$ hash")
+            raise RuntimeError(f"{backend} incorrectly rejected {IDENT_2B} hash")
         else:
             mixin_cls._fallback_ident = IDENT_2B
             assert_lacks_8bit_bug(IDENT_2B)
@@ -581,7 +581,7 @@ class _BcryptCommon(  # type: ignore[misc]
         elif ident == IDENT_2X:
             # NOTE: shouldn't get here.
             # XXX: could check if backend does actually offer 'support'
-            raise RuntimeError("$2x$ hashes not currently supported by passlib")
+            raise RuntimeError(f"{IDENT_2X} hashes not currently supported by passlib")
 
         else:
             raise AssertionError(f"unexpected ident value: {ident!r}")

--- a/passlib/handlers/bcrypt.py
+++ b/passlib/handlers/bcrypt.py
@@ -17,6 +17,8 @@ from importlib import metadata
 from importlib.util import find_spec
 from warnings import warn
 
+from packaging.version import parse
+
 import passlib.utils.handlers as uh
 from passlib._logging import logger
 from passlib.crypto.digest import compile_hmac
@@ -647,7 +649,7 @@ class _BcryptBackend(_BcryptCommon):
         try:
             version = metadata.version("bcrypt")
             # From bcrypt >= 5.0.0 is expected a failure on secrets greater than 72 characters
-            mixin_cls._fails_on_long_secrets = version >= "5.0.0"
+            mixin_cls._fails_on_long_secrets = parse(version) >= parse("5.0.0")
         except Exception:
             logger.warning("(trapped) error reading bcrypt version", exc_info=True)
             version = "<unknown>"

--- a/passlib/handlers/bcrypt.py
+++ b/passlib/handlers/bcrypt.py
@@ -604,8 +604,7 @@ class _BcryptCommon(  # type: ignore[misc]
         except ValueError as err:
             if not cls.is_password_too_long(secret, err):
                 raise
-            if cls.truncate_error:
-               raise uh.exc.PasswordTruncateError(cls) from err
+            cls._check_truncate_policy(secret)
             # silently truncate password to truncate_size bytes, and try again
             return backend.hashpw(secret[:cls.truncate_size], config)
 

--- a/tests/test_handlers_bcrypt.py
+++ b/tests/test_handlers_bcrypt.py
@@ -220,7 +220,7 @@ class _bcrypt_test(HandlerCase):
                 hash = IDENT_2B + hash[4:]
             hash = to_bytes(hash)
             try:
-                return self.handler.hash_password(bcrypt, secret, hash) == hash
+                return bcrypt.hashpw(secret, hash) == hash
             except ValueError:
                 raise ValueError(f"bcrypt rejected hash: {hash!r} (secret={secret!r})")
 

--- a/tests/test_handlers_bcrypt.py
+++ b/tests/test_handlers_bcrypt.py
@@ -220,7 +220,7 @@ class _bcrypt_test(HandlerCase):
                 hash = IDENT_2B + hash[4:]
             hash = to_bytes(hash)
             try:
-                return bcrypt.hashpw(secret, hash) == hash
+                return self.handler.hash_password(bcrypt, secret, hash) == hash
             except ValueError:
                 raise ValueError(f"bcrypt rejected hash: {hash!r} (secret={secret!r})")
 

--- a/tests/test_handlers_bcrypt.py
+++ b/tests/test_handlers_bcrypt.py
@@ -220,7 +220,7 @@ class _bcrypt_test(HandlerCase):
                 hash = IDENT_2B + hash[4:]
             hash = to_bytes(hash)
             try:
-                return bcrypt.hashpw(secret, hash) == hash
+                return self.handler.verify(secret, hash.decode('ascii'))
             except ValueError:
                 raise ValueError(f"bcrypt rejected hash: {hash!r} (secret={secret!r})")
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2126,11 +2126,10 @@ class HandlerCase(TestCase):
 
             # verify should truncate long secret before comparing
             # (unless truncate_verify_reject is set)
-            if not (cand_hasher and cand_hasher.truncate_verify_reject):
-                assert (
-                    self.do_verify(long_secret, short_hash, handler=cand_hasher)
-                    == long_verify_success
-                )
+            assert (
+                self.do_verify(long_secret, short_hash, handler=cand_hasher)
+                == long_verify_success
+            )
 
         # --------------------------------------------------
         # do tests on <truncate_size+1> length secret,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2075,7 +2075,7 @@ class HandlerCase(TestCase):
         # setup vars
         # --------------------------------------------------
         # try to get versions w/ and w/o truncate_error set.
-        # set to None if policy isn't configruable
+        # set to None if policy isn't configurable
         size_error_type = exc.PasswordSizeError
         if "truncate_error" in handler.setting_kwds:
             without_error = handler.using(truncate_error=False)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2126,10 +2126,11 @@ class HandlerCase(TestCase):
 
             # verify should truncate long secret before comparing
             # (unless truncate_verify_reject is set)
-            assert (
-                self.do_verify(long_secret, short_hash, handler=cand_hasher)
-                == long_verify_success
-            )
+            if not (cand_hasher and cand_hasher.truncate_verify_reject):
+                assert (
+                    self.do_verify(long_secret, short_hash, handler=cand_hasher)
+                    == long_verify_success
+                )
 
         # --------------------------------------------------
         # do tests on <truncate_size+1> length secret,


### PR DESCRIPTION
Improved version of [PR Update for BCrypt wrap bug detected #19](https://github.com/notypecheck/passlib/pull/19), based on [bcrypt improvements, test fixup #23](https://github.com/notypecheck/passlib/pull/23), including usage of `TruncateMixin` along with `passlib.exc.PasswordTruncateError`.

* Refer to [BCrypt wrap bug detected #18](https://github.com/notypecheck/passlib/issues/18)