### PR TITLE
test: fix bcrypt tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+from typing import Any
+
+import pytest
+
+from passlib.handlers.bcrypt import bcrypt
+
+
+@pytest.fixture(scope="session")
+def bcrypt_backend_raises_on_wraparound() -> bool:
+    try:
+        bcrypt.hash(secret="abc" * 100)
+    except ValueError:
+        return True
+    return False
+
+
+@pytest.fixture(scope="class")
+def bcrypt_backend_raises_on_wraparound_unittest(
+    request: Any,
+    bcrypt_backend_raises_on_wraparound: bool,
+):
+    request.cls.bcrypt_backend_raises_on_wraparound = (
+        bcrypt_backend_raises_on_wraparound
+    )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2059,13 +2059,10 @@ class HandlerCase(TestCase):
         alt_secret = secret[:-1] + alt
         assert not self.do_verify(alt_secret, hash), "full password not used in digest"
 
-    def test_secret_w_truncate_size(self):
+    def test_secret_with_truncate_size(self):
         """
         test password size limits raise truncate_error (if appropriate)
         """
-        # --------------------------------------------------
-        # check if test is applicable
-        # --------------------------------------------------
         handler = self.handler
         truncate_size = handler.truncate_size
         if not truncate_size:
@@ -2075,7 +2072,7 @@ class HandlerCase(TestCase):
         # setup vars
         # --------------------------------------------------
         # try to get versions w/ and w/o truncate_error set.
-        # set to None if policy isn't configruable
+        # set to None if policy isn't configurable
         size_error_type = exc.PasswordSizeError
         if "truncate_error" in handler.setting_kwds:
             without_error = handler.using(truncate_error=False)


### PR DESCRIPTION
This PR fixes test setup for `bcrypt` and `django_bcrypt` hashers by ignoring certain tests with `bcrypt>=5.0.0`, without changing any of the hashers themselves.
@chapmajs, @mo7ty, would like you to take a look too - I don't really like current test setup (they even fail if you move a testcase class into a different module 👀), this may just come from being unfamiliar with underlying code, but I find it really hard to work with.